### PR TITLE
Add frontend placeholder

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FlowAI Frontend</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 2rem;
+    }
+    .container {
+      max-width: 600px;
+      margin: auto;
+    }
+    input[type="text"] {
+      width: 100%;
+      padding: 0.5rem;
+      margin-bottom: 1rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    button {
+      padding: 0.5rem 1rem;
+      border: none;
+      background-color: #007bff;
+      color: white;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>FlowAI</h1>
+    <p>This is a placeholder frontend for the FlowAI application.</p>
+    <input type="text" id="userInput" placeholder="Type a message"/>
+    <button onclick="sendMessage()">Send</button>
+    <pre id="response"></pre>
+  </div>
+  <script>
+    function sendMessage() {
+      const input = document.getElementById('userInput').value;
+      const responseEl = document.getElementById('response');
+      // Placeholder for backend integration
+      responseEl.textContent = 'You typed: ' + input + '\n(Backend integration coming soon)';
+    }
+  </script>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,5 @@
-research - coming up
+# FlowAI
+
+This repository currently includes a simple placeholder frontend located in the `frontend` folder. Open `frontend/index.html` in a browser to test the interface.
+
+The frontend is a minimal starting point for the FlowAI application. Backend integration is not yet implemented.


### PR DESCRIPTION
## Summary
- add simple HTML/CSS/JS frontend in `frontend/index.html`
- update readme with brief instructions

## Testing
- `cat frontend/index.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688664be1ce883228f58bd807d348a09